### PR TITLE
Improvements to asset handler

### DIFF
--- a/asgineer/_app.py
+++ b/asgineer/_app.py
@@ -239,6 +239,7 @@ async def _handle_http(handler, request, receive, send):
         start_is_sent = False
         try:
             async for chunk in body:
+                print("Chunk!")
                 if isinstance(chunk, str):
                     chunk = chunk.encode()
                 if not isinstance(chunk, bytes):

--- a/asgineer/_app.py
+++ b/asgineer/_app.py
@@ -239,7 +239,6 @@ async def _handle_http(handler, request, receive, send):
         start_is_sent = False
         try:
             async for chunk in body:
-                print("Chunk!")
                 if isinstance(chunk, str):
                     chunk = chunk.encode()
                 if not isinstance(chunk, bytes):

--- a/asgineer/utils.py
+++ b/asgineer/utils.py
@@ -55,7 +55,7 @@ def make_asset_handler(assets, max_age=0, min_compress_size=256):
     * If the given path is not present in the asset dict (case insensitive),
       a 404-not-found response is returned.
     * The ``etag`` header is set to a (sha256) hash of the body of the asset.
-    * The ``cache-control`` header is set to "public must-revalidate max-age=xx".
+    * The ``cache-control`` header is set to "public, must-revalidate, max-age=xx".
     * If the request has a ``if-none-match`` header that matches the etag,
       the handler responds with 304 (indicating to the client that the resource
       is still up-to-date).
@@ -115,7 +115,7 @@ def make_asset_handler(assets, max_age=0, min_compress_size=256):
         request_etag = request.headers.get("if-none-match", None)
         headers = {
             "etag": content_etag,
-            "cache-control": f"public must-revalidate max-age={max_age:d}",
+            "cache-control": f"public, must-revalidate, max-age={max_age:d}",
         }
 
         # If client already has the exact asset, send confirmation now

--- a/examples/example_assets.py
+++ b/examples/example_assets.py
@@ -20,7 +20,7 @@ assets = {
 
 
 # Create a handler to server the dicts of assets
-asset_handler = asgineer.utils.make_asset_handler(assets)
+asset_handler = asgineer.utils.make_asset_handler(assets, max_age=100)
 
 
 @asgineer.to_asgi

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,14 @@
+import random
+
 import asgineer.utils
 
 from common import make_server, get_backend
 
 from pytest import raises, skip
 
+
+compressable_data = b"x" * 1000
+uncompressable_data = bytes([int(random.uniform(0, 255)) for i in range(1000)])
 
 # def test_normalize_response()  -> tested as part of test_app
 
@@ -19,7 +24,11 @@ def test_make_asset_handler():
         asgineer.utils.make_asset_handler({"notstrorbytes": 4})
 
     # Make a server
-    assets = {"foo.html": "bla", "foo.png": b"x" * 10000}
+    assets = {
+        "foo.html": "bla",
+        "foo.bmp": compressable_data,
+        "foo.png": uncompressable_data,
+    }
     assets.update({"b.xx": b"x", "t.xx": "x", "h.xx": "<html>x</html>"})
     assets.update({"big.html": "x" * 10000, "bightml": "<html>" + "x" * 100000})
     handler = asgineer.utils.make_asset_handler(assets)
@@ -28,35 +37,40 @@ def test_make_asset_handler():
     # Do simple requests and check validity
     r0 = server.get("foo")
     r1 = server.get("foo.html")
-    r2 = server.get("foo.png")
+    r2a = server.get("foo.bmp")
+    r2b = server.get("foo.png")
 
     assert r0.status == 404
-    assert r1.status == 200 and r2.status == 200
-    assert len(r1.body) == 3 and len(r2.body) == 10000
+    assert r1.status == 200 and r2a.status == 200 and r2b.status == 200
+    assert len(r1.body) == 3 and len(r2a.body) == 1000, len(r2b.body) == 1000
 
     assert r1.headers["content-type"] == "text/html"
-    assert r2.headers["content-type"] == "image/png"
+    assert r2b.headers["content-type"] == "image/png"
 
     assert server.get("h.xx").headers["content-type"] == "text/html"
     assert server.get("t.xx").headers["content-type"] == "text/plain"
     assert server.get("b.xx").headers["content-type"] == "application/octet-stream"
 
     assert r1.headers["etag"]
-    assert r2.headers["etag"]
-    assert r1.headers["etag"] != r2.headers["etag"]
+    assert r2a.headers["etag"]
+    assert r2b.headers["etag"]
+    assert r2a.headers["etag"] != r2b.headers["etag"]
 
     assert r1.headers.get("content-encoding", "identity") == "identity"
-    assert r2.headers.get("content-encoding", "identity") == "identity"
+    assert r2a.headers.get("content-encoding", "identity") == "identity"
+    assert r2b.headers.get("content-encoding", "identity") == "identity"
 
     # Now do request with gzip on
     r3 = server.get("foo.html", headers={"accept-encoding": "gzip"})
-    r4 = server.get("foo.png", headers={"accept-encoding": "gzip"})
+    r4a = server.get("foo.bmp", headers={"accept-encoding": "gzip"})
+    r4b = server.get("foo.png", headers={"accept-encoding": "gzip"})
 
-    assert r3.status == 200 and r4.status == 200
-    assert len(r3.body) == 3 and len(r4.body) < 100
+    assert r3.status == 200 and r4a.status == 200 and r4b.status == 200
+    assert len(r3.body) == 3 and len(r4a.body) < 50 and len(r4b.body) == 1000
 
     assert r3.headers.get("content-encoding", "identity") == "identity"  # small
-    assert r4.headers.get("content-encoding", "identity") == "gzip"  # big enough
+    assert r4a.headers.get("content-encoding", "identity") == "gzip"  # big enough
+    assert r4b.headers.get("content-encoding", "identity") == "identity"  # entropy
 
     # Now do a request with etag
     r5 = server.get(
@@ -65,7 +79,7 @@ def test_make_asset_handler():
     )
     r6 = server.get(
         "foo.png",
-        headers={"accept-encoding": "gzip", "if-none-match": r2.headers["etag"]},
+        headers={"accept-encoding": "gzip", "if-none-match": r2b.headers["etag"]},
     )
 
     assert r5.status == 304 and r6.status == 304
@@ -77,14 +91,14 @@ def test_make_asset_handler():
     # Dito, but with wrong etag
     r7 = server.get(
         "foo.html",
-        headers={"accept-encoding": "gzip", "if-none-match": r2.headers["etag"]},
+        headers={"accept-encoding": "gzip", "if-none-match": r2b.headers["etag"]},
     )
     r8 = server.get(
         "foo.png", headers={"accept-encoding": "gzip", "if-none-match": "xxxx"}
     )
 
     assert r7.status == 200 and r8.status == 200
-    assert len(r1.body) == 3 and len(r2.body) == 10000
+    assert len(r7.body) == 3 and len(r8.body) == 1000
 
     # Big html files will be zipped, but must retain content type
     for fname in ("big.html", "bightml"):


### PR DESCRIPTION
* Don't compress png's (and other assets that already have max entropy). Closes #29
* Make sure to not compress video assets. Closes #30
* Fix cache-control header (not sure how broken it was, but the lighthouse tool did not detect max-age).