### PR TITLE
Long-lasting connections

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 2-Clause License
 
-Copyright (c) 2018, Almar Klein
+Copyright (c) 2018-2020, Almar Klein
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A really thin ASGI web framework 🐍🤘
 [![Build Status](https://api.travis-ci.org/almarklein/asgineer.svg)](https://travis-ci.org/almarklein/asgineer)
 [![Documentation Status](https://readthedocs.org/projects/asgineer/badge/?version=latest)](https://asgineer.readthedocs.io/?badge=latest)
 [![Package Version](https://badge.fury.io/py/asgineer.svg)](https://pypi.org/project/asgineer)
-    
+
 
 ## Introduction
 
@@ -16,7 +16,9 @@ offering a friendly API. The
 minutes to read!
 
 When running Asgineer on [Uvicorn](https://github.com/encode/uvicorn),
-it is one of the fastest web frameworks available.
+it is one of the fastest web frameworks available. It supports http
+long polling, server side events (SSE), and websockets. And has utilities
+to serve assets the right (and fast) way.
 
 
 ## Example
@@ -44,7 +46,7 @@ $ uvicorn example:main --host=localhost --port=8080
 
 Asgineer needs Python 3.6 or higher. To install or upgrade, run:
 ```
-$ pip install asgineer --upgrade
+$ pip install -U asgineer
 ```
 
 Asgineer has zero hard dependencies, but it
@@ -59,7 +61,7 @@ needs an ASGI server to run on, like
 Extra dev dependencies: `pip install invoke pytest pytest-cov black flake8 requests websockets`
 
 Run `invoke -l` to get a list of dev commands, e.g.:
-    
+
 * `invoke autoformat` to apply Black code formatting.
 * `invoke lint` to test for unused imports and more.
 * `invoke tests` to run the tests, optionally set the `ASGI_SERVER` environment variable.

--- a/asgineer/__init__.py
+++ b/asgineer/__init__.py
@@ -3,12 +3,24 @@ Asgineer - A really thin ASGI web framework
 """
 
 from ._request import BaseRequest, HttpRequest, WebsocketRequest
+from ._request import RequestSet, DisconnectedError
 from ._app import to_asgi
 from ._run import run
 from . import utils
+from ._compat import sleep
 
 
-__all__ = ["BaseRequest", "HttpRequest", "WebsocketRequest", "to_asgi", "run", "utils"]
+__all__ = [
+    "BaseRequest",
+    "HttpRequest",
+    "WebsocketRequest",
+    "RequestSet",
+    "DisconnectedError",
+    "to_asgi",
+    "run",
+    "utils",
+    "sleep",
+]
 
 
 __version__ = "0.7.1"

--- a/asgineer/__init__.py
+++ b/asgineer/__init__.py
@@ -7,7 +7,7 @@ from ._request import RequestSet, DisconnectedError
 from ._app import to_asgi
 from ._run import run
 from . import utils
-from ._compat import sleep
+from .utils import sleep
 
 
 __all__ = [

--- a/asgineer/_app.py
+++ b/asgineer/_app.py
@@ -246,6 +246,8 @@ async def _handle_http(handler, request):
         if request._app_state == _request.CONNECTING:
             await request.accept(500, {})
             await request.send(error_text, more=False)
+        elif request._app_state == _request.CONNECTED:
+            await request.send(b"", more=False)  # At least close it
 
     finally:
 

--- a/asgineer/_app.py
+++ b/asgineer/_app.py
@@ -145,6 +145,9 @@ async def _handle_websocket(handler, request):
             )
             raise IOError(error_text)
 
+    except DisconnectedError:
+        pass  # Not really an error
+
     except Exception as err:
         error_text = f"{type(err).__name__} in websocket handler: {str(err)}"
         logger.error(error_text, exc_info=err)

--- a/asgineer/_app.py
+++ b/asgineer/_app.py
@@ -155,14 +155,7 @@ async def _handle_websocket(handler, request):
     finally:
 
         # The ASGI spec specifies that ASGI servers should close
-        # the ws connection when the task ends. At the time of
-        # writing (04-10-2018), only Uvicorn does this.
-        # So ... just close for good measure.
-        # todo: can we remove this?
-        try:
-            await request.close()
-        except Exception:  # pragma: no cover
-            pass
+        # the ws connection when the task ends.
 
         # Also clean up
         try:

--- a/asgineer/_app.py
+++ b/asgineer/_app.py
@@ -158,13 +158,13 @@ async def _handle_websocket(handler, request):
         # todo: can we remove this?
         try:
             await request.close()
-        except Exception:
+        except Exception:  # pragma: no cover
             pass
 
         # Also clean up
         try:
             await request._destroy()
-        except Exception as err:
+        except Exception as err:  # pragma: no cover
             logger.error(f"Error in ws cleanup: {str(err)}", exc_info=err)
 
 
@@ -249,5 +249,5 @@ async def _handle_http(handler, request):
         # Clean up
         try:
             await request._destroy()
-        except Exception as err:
+        except Exception as err:  # pragma: no cover
             logger.error(f"Error in cleanup: {str(err)}", exc_info=err)

--- a/asgineer/_compat.py
+++ b/asgineer/_compat.py
@@ -1,0 +1,24 @@
+import asyncio
+
+
+async def sleep(seconds):
+    """ An async sleep function. Uses asyncio. Can be extended to support Trio
+    once we support that.
+    """
+
+    if True:  # if asyncio
+        await asyncio.sleep(seconds)
+
+
+Event = asyncio.Event
+
+
+async def wait_for_any_then_cancel_the_rest(*coroutines):
+    """ Wait for any of the given coroutines to complete (or fail), and then
+    cancels all the other co-routines.
+    """
+    if True:  # if asyncio
+        tasks = [asyncio.create_task(co) for co in coroutines]
+        done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+        for task in pending:
+            task.cancel()

--- a/asgineer/_compat.py
+++ b/asgineer/_compat.py
@@ -17,8 +17,9 @@ async def wait_for_any_then_cancel_the_rest(*coroutines):
     """ Wait for any of the given coroutines to complete (or fail), and then
     cancels all the other co-routines.
     """
+    # Note: ensure_future == create_task. Less readable, but py36 compatible.
     if True:  # if asyncio
-        tasks = [asyncio.create_task(co) for co in coroutines]
+        tasks = [asyncio.ensure_future(co) for co in coroutines]
         done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
         for task in pending:
             task.cancel()

--- a/asgineer/_compat.py
+++ b/asgineer/_compat.py
@@ -1,3 +1,9 @@
+"""
+This module provides compatibility for different async libs. Currently
+only supporting asyncio, but should not be too hard to add e.g. Trio,
+once Uvicorn has Trio support.
+"""
+
 import asyncio
 
 

--- a/asgineer/_request.py
+++ b/asgineer/_request.py
@@ -413,8 +413,6 @@ class WebsocketRequest(BaseRequest):
         await self._send({"type": "websocket.close", "code": code})
         self._app_state = DISCONNECTED
 
-    # todo: implement sleep_while_connected, and wakeup
-
 
 class RequestSet:
     """ A set of request objects that are currenlty active.

--- a/asgineer/_request.py
+++ b/asgineer/_request.py
@@ -18,7 +18,8 @@ DISCONNECTED = 3
 
 class DisconnectedError(IOError):
     """ An error raised when the connection is disconnected by the client.
-    Subclass of IOError.
+    Subclass of IOError. You don't need to catch these - it is considered
+    ok for a handler to exit by this.
     """
 
 

--- a/asgineer/_request.py
+++ b/asgineer/_request.py
@@ -223,8 +223,8 @@ class HttpRequest(BaseRequest):
             raise IOError("Cannot send to a closed connection.")
 
     async def sleep_while_connected(self, seconds):
-        """ A method similar to ``asyncio.sleep()``, intended for use in long
-        polling and server side events (SSE):
+        """ Async sleep, wake-able, and only while the connection is active.
+        Intended for use in long polling and server side events (SSE):
 
         * Returns after the given amount of seconds.
         * Returns when the request ``wakeup()`` is called.

--- a/asgineer/_request.py
+++ b/asgineer/_request.py
@@ -452,10 +452,3 @@ class RequestSet:
         """ Remove all request objects from the set.
         """
         self._s.clear()
-
-    async def wakeup_all(self):
-        """ Wake up all tasks that are waiting for any of the request's
-        ``sleep_while_connected`` coroutine.
-        """
-        for request in self._s:
-            await request.wakeup()

--- a/asgineer/testutils.py
+++ b/asgineer/testutils.py
@@ -540,7 +540,7 @@ class MockTestServer(BaseTestServer):
 
         class WS:
             def __init__(self):
-                self._closed = False
+                self._closed_server = False
                 self._accepted = False
 
             async def send(self, value):
@@ -554,14 +554,14 @@ class MockTestServer(BaseTestServer):
 
             async def receive(self):
                 # Wait for message to become available
-                if self._closed:
+                if self._closed_server:
                     raise IOError("WS is closed")
                 while not server_to_client:
                     await asyncio.sleep(0.02)
                 # Get message and handle special cases
                 m = server_to_client.pop(0)
                 if m["type"] in ("websocket.disconnect", "websocket.close"):
-                    self._closed = True
+                    self._closed_server = True
                     raise IOError("WS closed")
                 if m["type"] == "websocket.accept":
                     self._accepted = True
@@ -571,7 +571,6 @@ class MockTestServer(BaseTestServer):
 
             async def close(self):
                 client_to_server.append({"type": "websocket.disconnect"})
-                self._closed = True
 
             async def __aiter__(self):
                 while True:

--- a/asgineer/testutils.py
+++ b/asgineer/testutils.py
@@ -136,7 +136,8 @@ class BaseTestServer:
             url = self.url + "/" + path.lstrip("/")
 
         co = self._co_request(method, url, data=data, headers=headers, **kwargs)
-        status, headers, body = self._loop.run_until_complete(co)
+        co_res = self._loop.run_until_complete(co)
+        status, headers, body = co_res
         return Response(status, headers, body)
 
     def ws_communicate(self, path, client_co_func, loop=None):

--- a/asgineer/testutils.py
+++ b/asgineer/testutils.py
@@ -544,6 +544,8 @@ class MockTestServer(BaseTestServer):
                 self._accepted = False
 
             async def send(self, value):
+                if self._closed_server:
+                    raise IOError("ConnectionClosed")
                 if isinstance(value, bytes):
                     m = {"type": "websocket.receive", "bytes": value}
                 elif isinstance(value, str):

--- a/asgineer/utils.py
+++ b/asgineer/utils.py
@@ -7,9 +7,14 @@ import hashlib
 import mimetypes
 
 from ._app import normalize_response, guess_content_type_from_body
+from ._compat import sleep
 
-
-__all__ = ["normalize_response", "make_asset_handler", "guess_content_type_from_body"]
+__all__ = [
+    "sleep",
+    "normalize_response",
+    "make_asset_handler",
+    "guess_content_type_from_body",
+]
 
 VIDEO_EXTENSIONS = ".mp4", ".3gp", ".webm"
 

--- a/asgineer/utils.py
+++ b/asgineer/utils.py
@@ -71,7 +71,8 @@ def make_asset_handler(assets, max_age=0, min_compress_size=256):
 
     if not isinstance(assets, dict):
         raise TypeError("make_asset_handler() expects a dict of assets")
-    assert isinstance(max_age, int) and max_age >= 0
+    if not (isinstance(max_age, int) and max_age >= 0):  # pragma: no cover
+        raise TypeError("make_asset_handler() max_age must be a positive int")
 
     # Copy the dict, store hashes, prepare zipped data
     assets = dict((key.lower(), val) for (key, val) in assets.items())
@@ -102,7 +103,8 @@ def make_asset_handler(assets, max_age=0, min_compress_size=256):
             ctypes[key] = guess_content_type_from_body(val)
 
     async def asset_handler(request, path=None):
-        assert request.method in ("GET", "HEAD")
+        if request.method not in ("GET", "HEAD"):
+            return 405, {}, "Method not allowed"
         if path is None:
             path = request.path.lstrip("/")
         path = path.lower()

--- a/docs/asgi.rst
+++ b/docs/asgi.rst
@@ -9,35 +9,31 @@ but here's a short summary.*
 What is ASGI?
 =============
 
-The `ASGI <https://asgi.readthedocs.io>`_ specification allows async web
-servers and frameworks to talk to each-other in a standardized way. You can select
-a framework (like Asgineer, Quart, Starlette, etc.) based on how you want to write
-your code, and you select a server (like Uvicorn, Hypercorn, Daphne) based on how
-fast/reliable/secure you want it to be.
+The `ASGI <https://asgi.readthedocs.io>`_ specification allows async
+web servers and frameworks to talk to each-other in a standardized way.
+You can select a framework (like Asgineer, Starlette, Responder, Quart,
+etc.) based on how you want to write your code, and you select a server
+(like Uvicorn, Hypercorn, Daphne) based on how fast/reliable/secure you
+want it to be.
 
 ASGI is like WSGI, but for async.
 
 In particular, the main part of an ASGI application looks something like this:
-    
+
 .. code-block:: python
 
-    class Application:
-    
-        def __init__(self, scope):
-            self.scope = scope
-    
-        async def __call__(self, receive, send):
-            ...
+    async def application(scope, receive, send):
+        ...
 
 
 Asgineer and other ASGI frameworks
 ==================================
 
-ASGI is great, but writing web apps directly in ASGI format is silly.
-Asgineer is a tiny layer on top. It's so minimal that it still feels a
-bit like ASGI, but nicer.
+ASGI is great, but writing web apps directly in ASGI format is tedious.
+Asgineer is a tiny layer on top; it still feels a bit like ASGI, but nicer.
 
 Other ASGI frameworks include
 `Starlette <https://github.com/encode/starlette>`_,
+`Responder <https://github.com/taoufik07/responder>`_,
 `Quart <https://github.com/pgjones/quart>`_, and
 `others <https://asgi.readthedocs.io/en/latest/implementations.html#application-frameworks>`_.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "Asgineer"
-copyright = "2018-2019, Almar Klein"
+copyright = "2018-2020, Almar Klein"
 author = "Almar Klein"
 
 # The short X.Y version.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,12 +16,14 @@ More precisely, Asgineer is a (thin) Python ASGI web microframework.
 
 Cool stuff:
 
-* Since Asgineer does not depend on ``asyncio``, it can be used with alternative
-  async libs like `Trio <https://github.com/python-trio/trio>`_.
 * When running on `Uvicorn <https://github.com/encode/uvicorn>`_, Asgineer is one
   of the fastest web frameworks available.
+* Asgineer has great support for chunked responses, long polling, server
+  side events (SSE), and websockets.
+* Asgineer has utilities to help you serve your assets the right (and fast) way.
 * You can write your web app with Asgineer, and switch the underlying (ASGI) server
   without having to change your code.
+* Great test coverage.
 * Asgineer is so small that it fits in the palm of your hand!
 
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -32,6 +32,7 @@ sets the appropriate headers:
   and the ``content-type`` header defaults to ``text/plain``.
 * A ``dict`` object is JSON-encoded,
   and the ``content-type`` header is set to ``application/json``.
+* An async generator can be provided as an alternative way to send a chunked response.
 
 See :func:`request.accept <asgineer.HttpRequest.accept>` and :func:`request.send <asgineer.HttpRequest.send>`
 for a lower level API (for which the auto-conversion does not apply).

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -6,24 +6,12 @@ This page contains the API documentation of Asgineer's functions and classes,
 as well as a description of Asgineer more implicit API.
 
 
-The functions
-=============
-
-.. autofunction:: asgineer.to_asgi
-
-.. autofunction:: asgineer.run
-
-
 How to return a response
 ========================
 
-An HTTP response consists of three things: an integer
-`status code <https://en.wikipedia.org/wiki/List_of_HTTP_status_codes>`_,
-a dictionary of `headers <https://en.wikipedia.org/wiki/List_of_HTTP_header_fields>`_,
-and the response `body <https://en.wikipedia.org/wiki/HTTP_message_body>`_.
-Many web frameworks wrap these up in a response object. In Asgineer you
-just return them. You can also return just the body, or the body and
-headers; these are all equivalent:
+An HTTP response consists of three things: a status code, headers, and the body.
+Your handler must return these as a tuple. You can also return just the
+body, or the body and headers; these are all equivalent:
 
 .. code-block:: python
 
@@ -33,8 +21,9 @@ headers; these are all equivalent:
 
 If needed, the :func:`.normalize_response` function can be used to
 turn a response (e.g. of a subhandler) into a 3-element tuple.
-In the end, the body of an HTTP response is always binary, but Asgineer
-handles some common cases for you:
+
+Asgineer automatically converts the body returned by your handler, and
+sets the appropriate headers:
 
 * A ``bytes`` object is passed unchanged.
 * A ``str`` object that starts with ``<!DOCTYPE html>`` or ``<html>`` is UTF-8 encoded,
@@ -44,23 +33,12 @@ handles some common cases for you:
 * A ``dict`` object is JSON-encoded,
   and the ``content-type`` header is set to ``application/json``.
 
-Responses can also be send in chunks by returning an async generator (which
-must yield ``bytes`` or ``str`` objects). Asgineer will use the generator to stream
-the body to the client:
-
-.. code-block:: python
-    
-    async def chunkgenerator():
-        for chunk in ['foo', 'bar', 'spam', 'eggs']:
-            # ... do work or async sleep here ...
-            yield chunk
-    
-    async def handler(request):
-        return 200, {}, chunkgenerator()
+See :func:`request.accept <asgineer.HttpRequest.accept>` and :func:`request.send <asgineer.HttpRequest.send>`
+for a lower level API (for which the auto-conversion does not apply).
 
 
-The Request classes
-===================
+Requests
+========
 
 .. autoclass:: asgineer.BaseRequest
     :members:
@@ -71,23 +49,20 @@ The Request classes
 .. autoclass:: asgineer.WebsocketRequest
     :members:
 
+.. autoclass:: asgineer.RequestSet
+    :members:
 
-Details on Asgineer's behavior
-==============================
+.. autoclass:: asgineer.DisconnectedError
+    :members:
 
-Asgineer will invoke your main handler for each incoming request. If an
-exception is raised inside the handler, this exception will be logged
-(including ``exc_info``) using the logger that can be obtained with
-``logging.getLogger("asgineer")``, which by default writes to stderr. A
-status 500 (internal server error) response is sent back, and the error
-message (without traceback) is included (if the response has not yet been sent).
 
-Similarly, when the returned response is flawed, a (slightly different)
-error message is logged and included in the response.
+Entrypoint functions
+====================
 
-In fact, Asgineer handles all exceptions, since the ASGI servers log
-errors in different ways (some just ignore them). If an error does fall
-through, it can be considered a bug.
+.. autofunction:: asgineer.to_asgi
+
+.. autofunction:: asgineer.run
+
 
 
 Utility functions
@@ -95,8 +70,28 @@ Utility functions
 
 The ``asgineer.utils`` module provides a few utilities for common tasks.
 
+.. autofunction:: asgineer.utils.sleep
+
 .. autofunction:: asgineer.utils.make_asset_handler
 
 .. autofunction:: asgineer.utils.normalize_response
 
 .. autofunction:: asgineer.utils.guess_content_type_from_body
+
+
+Details on Asgineer's behavior
+==============================
+
+Asgineer will invoke your main handler for each incoming request. If an
+exception is raised inside the handler, this exception will be logged
+(including ``exc_info``) using the logger that can be obtained with
+``logging.getLogger("asgineer")``, which by default writes to stderr.
+If possible, a status 500 (internal server error) response is sent back
+that includes the error message (without traceback).
+
+Similarly, when the returned response is flawed, a (slightly different)
+error message is logged and included in the response.
+
+In fact, Asgineer handles all exceptions, since the ASGI servers log
+errors in different ways (some just ignore them). If an error does fall
+through, it can be considered a bug.

--- a/docs/start.rst
+++ b/docs/start.rst
@@ -9,8 +9,8 @@ Installation
 Asgineer need Python 3.6 or higher. To install or upgrade, run:
 
 .. code-block:: shell
-    
-    $ pip install asgineer --upgrade
+
+    $ pip install -U asgineer
 
 
 Dependencies

--- a/examples/example_chat.py
+++ b/examples/example_chat.py
@@ -1,0 +1,200 @@
+"""
+"""
+
+import time
+import asyncio
+
+import asgineer
+
+
+@asgineer.to_asgi
+async def main(request):
+    if request.path == "/":
+        return HTML_TEMPLATE.replace("POLL_METHOD", "none")
+    elif request.path == "/short_poll":
+        return HTML_TEMPLATE.replace("POLL_METHOD", "short_poll")
+    elif request.path == "/long_poll":
+        return HTML_TEMPLATE.replace("POLL_METHOD", "long_poll")
+    elif request.path == "/sse":
+        return HTML_TEMPLATE.replace("POLL_METHOD", "sse")
+    elif request.path == "/websocket":
+        return HTML_TEMPLATE.replace("POLL_METHOD", "websocket")
+    elif request.path == "/say":
+        message_bytes = await request.get_body(1024)
+        await post_new_message(message_bytes.decode())
+        return 200, {}, ""
+    elif request.path.startswith("/messages/"):
+        return await messages_handler(request)
+    else:
+        return 404, {}, "not found"
+
+
+messages = []
+waiting_requests = asgineer.RequestSet()
+
+
+async def post_new_message(message):
+    messages.append(message)
+    messages[:-32] = []
+    await waiting_requests.wakeup_all()
+
+
+# todo: if a new message is say-ed before we enter the sleep, we wont get it.
+
+
+async def messages_handler(request):
+    poll_method = request.path.split("/", 2)[-1]
+
+    if poll_method == "short_poll":
+        # Short poll: simply respond with the messages
+        # return 200, {}, "<br>".join(messages)
+        await request.accept(200, {"content-type": "text/plain"})
+        await request.send("<br>".join(messages))
+
+    elif poll_method == "long_poll":
+        # Long poll: wait with sending messages until we have new data
+        # return 200, {}, messages_long_poll(request)
+        waiting_requests.add(request)
+        await request.accept(200, {"content-type": "text/plain"})
+        await request.sleep_while_connected(10)
+        await request.send("<br>".join(messages))
+
+    elif poll_method == "sse":
+        # Server Side Events: send messages each time we have new data
+        # Also need special headers
+        waiting_requests.add(request)
+        sse_headers = {
+            "content-type": "text/event-stream",
+            "cache-control": "no-cache",
+            "connection": "keep-alive",
+        }
+        # return 200, sse_headers, (messages_sse(request), wait_for_disconnect(request))
+        await request.accept(200, sse_headers)
+        while True:
+            await request.sleep_while_connected(10)
+            await request.send(f"event: message\ndata: {'<br>'.join(messages)}\n\n")
+
+    elif poll_method == "websocket":
+        # return await messages_websocket(request)
+        assert request.scope["type"] == "websocket", "Expected ws"
+        waiting_requests.add(request)
+        await request.accept()
+        while True:
+            await request.sleep_while_connected(10)
+            await request.send("<br>".join(messages))
+            print("ws", time.time())
+
+    else:
+        raise ValueError(f"Invalid message handler endpoint: {request.path}")
+
+
+HTML_TEMPLATE = """
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Asgineer example polling: POLL_METHOD</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>
+
+<script>
+function set_text(text) {
+    var el = document.getElementById("messages");
+    el.innerHTML = text;
+}
+
+
+async function do_short_poll() {
+    let response = await fetch("/messages/short_poll");
+    if (response.status == 200) { set_text(await response.text()); }
+}
+
+async function do_long_poll() {
+    let response = await fetch("/messages/long_poll");
+    if (response.status == 200) {
+        set_text(await response.text());
+        do_long_poll(); // schedule a new long poll
+    }
+}
+
+async function do_sse() {
+    var evtSource = new EventSource("/messages/sse");
+    evtSource.addEventListener("message", function(event) { set_text(event.data); });
+}
+
+async function do_websocket() {
+    ws = new WebSocket('ws://' + window.location.host + '/messages/websocket');
+    //var ws = new WebSocket('/messages/websocket');
+    ws.onmessage = function(m) {
+        set_text(m.data);
+    }
+}
+
+
+window.onload = function () {
+    // Do a short poll on startup
+    do_short_poll();
+
+    // Select polling scheme based on path
+    var poll_method = 'POLL_METHOD';
+    if (poll_method == 'short_poll') {
+        setInterval(do_short_poll, 2000);
+    } else if (poll_method == 'long_poll') {
+        do_long_poll();
+    } else if (poll_method == 'sse') {
+        do_sse();
+    } else if (poll_method == 'websocket') {
+        do_websocket();
+    }
+
+    var textinput = document.getElementById("text");
+    textinput.value = '';
+    var button = document.getElementById("button");
+    button.onclick = function () {
+        if (textinput.value) {
+            fetch("/say", {method: 'post', body: textinput.value});
+            textinput.value = '';
+        }
+    }
+}
+</script>
+
+<style>
+html { height: 100%; }
+body { height: 100%; padding: 0; }
+body, .main, .messages, .userinput { margin: 0; }
+.main { position: absolute; top:0; bottom:0; width: 600px; left: calc(50% - 300px); }
+.messages, .userinput { background: #def; border-radius: 5px; padding: 5px; margin-top: 5px; }
+.messages { height: calc(100% - 100px); overflow-y: scroll; }
+.userinput { height: 45px; }
+.userinput > input { height: 45px; border-radius: 5px; box-sizing:border-box; }
+.userinput > input[type=text] { width: 500px; }
+.userinput > input[type=button] { width: 80px; }
+}
+</style>
+
+<div style='padding: 15px'>
+    Current polling method: POLL_METHOD<br /><br />
+    <a href="/">No polling (only on page load)</a><br />
+    <a href="/short_poll">Short Polling</a><br />
+    <a href="/long_poll">Long Polling</a><br />
+    <a href="/sse">Server Side Events (SSE)</a><br />
+    <a href="/websocket">Websockets</a><br />
+</a>
+
+<div class='main'>
+    <div class="messages" id="messages"></div>
+    <div class="userinput">
+        <input type='text' id='text' placeholder='Your message ...' />
+        <input type='button' id='button' value='Send' />
+    </div>
+</div>
+
+</body>
+</html>
+""".lstrip()
+
+
+if __name__ == "__main__":
+    asgineer.run(main, "uvicorn", "localhost:80")

--- a/examples/example_chat.py
+++ b/examples/example_chat.py
@@ -9,9 +9,6 @@ See example_ws_chat.py for a similar chat based on websockets. Note that
 SSE could follow a more hybrid approach.
 """
 
-import time
-import asyncio
-
 import asgineer
 
 

--- a/examples/example_http.py
+++ b/examples/example_http.py
@@ -106,19 +106,12 @@ async def chunks(request):
     but only displays it when done. This e.g. allows streaming large
     files without using large amounts of memory.
     """
-    # Little triage to support both Trio and asyncio based apps
-    import sys
-
-    if "trio" in sys.modules:
-        import trio as aio
-    else:
-        import asyncio as aio
 
     async def iter():
         yield "<html><head></head><body>"
         yield "Here are some chunks dripping in:<br>"
         for i in range(20):
-            await aio.sleep(0.1)
+            await asgineer.sleep(0.1)
             yield "CHUNK <br>"
         yield "</body></html>"
 

--- a/examples/example_middleware.py
+++ b/examples/example_middleware.py
@@ -20,4 +20,4 @@ main = GZipMiddleware(main, minimum_size=1024)
 
 
 if __name__ == "__main__":
-    asgineer.run(f"__main__:main", "uvicorn")
+    asgineer.run("__main__:main", "uvicorn")

--- a/examples/example_request_info.py
+++ b/examples/example_request_info.py
@@ -14,7 +14,7 @@ async def main(request):
         f"<h2>request.url</h2>{request.url}",
         f"<h2>request.path</h2>{request.path}",
         f"<h2>request.querydict</h2>{request.querydict}",
-        f"<h2>request.headers</h2>",
+        "<h2>request.headers</h2>",
         "<br>".join(f"{key}: {val!r}" for key, val in request.headers.items()),
         "<br>",
         "</body></html>",

--- a/examples/example_ws_chat.py
+++ b/examples/example_ws_chat.py
@@ -8,9 +8,6 @@ exits. The request is automatically removed from waiting_requests
 (that's the point of RequestSet).
 """
 
-import time
-import asyncio
-
 import asgineer
 
 

--- a/examples/example_ws_chat.py
+++ b/examples/example_ws_chat.py
@@ -31,9 +31,9 @@ async def main(request):
 async def ws_handler(request):
     waiting_requests.add(request)
     while True:
-        message = await request.receive()
+        msg = await request.receive()  # raises DisconnectedError on disconnect
         for r in waiting_requests:
-            await r.send(message)
+            await r.send(msg)
 
 
 HTML_TEMPLATE = """

--- a/examples/example_ws_chat.py
+++ b/examples/example_ws_chat.py
@@ -1,0 +1,97 @@
+"""
+Example chat application using websockets.
+
+The handler is waiting for a message most of the time. When it receives
+one, it sends it to all other websockets. When the websocket
+disconnects, request.receive() raises DisconnectedError and the handler
+exits. The request is automatically removed from waiting_requests
+(that's the point of RequestSet).
+"""
+
+import time
+import asyncio
+
+import asgineer
+
+
+waiting_requests = asgineer.RequestSet()
+
+
+@asgineer.to_asgi
+async def main(request):
+    if request.path == "/":
+        return HTML_TEMPLATE
+    elif request.path == "/ws":
+        await request.accept()
+        await ws_handler(request)
+    else:
+        return 404, {}, "not found"
+
+
+async def ws_handler(request):
+    waiting_requests.add(request)
+    while True:
+        message = await request.receive()
+        for r in waiting_requests:
+            await r.send(message)
+
+
+HTML_TEMPLATE = """
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Asgineer WS chat example</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>
+
+<script>
+ws = new WebSocket('ws://' + window.location.host + '/ws');
+ws.onmessage = function(m) {
+    var el = document.getElementById("messages");
+    el.innerHTML += m.data + "<br>";
+}
+
+window.onload = function () {
+    var textinput = document.getElementById("text");
+    textinput.value = '';
+    var button = document.getElementById("button");
+    button.onclick = function () {
+        if (textinput.value) {
+            ws.send(textinput.value);
+            textinput.value = '';
+        }
+    }
+}
+</script>
+
+<style>
+html { height: 100%; }
+body { height: 100%; padding: 0; }
+body, .main, .messages, .userinput { margin: 0; }
+.main { position: absolute; top:0; bottom:0; width: 600px; left: calc(50% - 300px); }
+.messages, .userinput { background: #def; border-radius: 5px; padding: 5px; margin-top: 5px; }
+.messages { height: calc(100% - 100px); overflow-y: scroll; }
+.userinput { height: 45px; }
+.userinput > input { height: 45px; border-radius: 5px; box-sizing:border-box; }
+.userinput > input[type=text] { width: 500px; }
+.userinput > input[type=button] { width: 80px; }
+}
+</style>
+
+<div class='main'>
+    <div class="messages" id="messages"></div>
+    <div class="userinput">
+        <input type='text' id='text' placeholder='Your message ...' />
+        <input type='button' id='button' value='Send' />
+    </div>
+</div>
+
+</body>
+</html>
+""".lstrip()
+
+
+if __name__ == "__main__":
+    asgineer.run(main, "uvicorn", "localhost:80")

--- a/examples/example_ws_echo.py
+++ b/examples/example_ws_echo.py
@@ -1,5 +1,5 @@
 """
-Demonstrate websocket usage.
+Example websocket app that echos websocket messages.
 """
 
 import asgineer
@@ -39,25 +39,22 @@ async def main(request):
     if not request.path.rstrip("/"):
         return index  # Asgineer sets the text/html content type
     elif request.path.startswith("/ws"):
-        return await websocket_handler(request)
+        assert request.scope["type"] == "websocket", "Expected ws"
+        await request.accept()
+        await websocket_handler(request)
     else:
         return 404, {}, f"404 not found {request.path}"
 
 
 async def websocket_handler(request):
-    assert request.scope["type"] == "websocket", "Expected ws"
     print("request", request)
-
-    await request.accept()
     await request.send("hello!")
-
-    async for m in request.receive_iter():
+    while True:
+        m = await request.receive()
         await request.send("echo: " + str(m))
         print(m)
 
     print("done")
-    # The moment that we return, the websocket will be closed
-    # (if the ASGI server behaves correctly)
 
 
 if __name__ == "__main__":

--- a/tasks.py
+++ b/tasks.py
@@ -13,7 +13,13 @@ from invoke import task
 
 NAME = "asgineer"
 LIBNAME = NAME.replace("-", "_")
-PY_PATHS = [LIBNAME, "tests", "tasks.py", "setup.py"]  # for linting/formatting
+PY_PATHS = [
+    LIBNAME,
+    "examples",
+    "tests",
+    "tasks.py",
+    "setup.py",
+]
 
 # ----------------------------------------
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -320,6 +320,42 @@ def test_chunking_fails():
     assert "already consumed" in res.body.decode().lower()
     assert "already consumed" in p.out.lower()
 
+    # Read fail - sleep_while_connected consumes data
+
+    async def handler_chunkfail4(request):
+        await request.sleep_while_connected(1.0)
+        chunks = []
+        async for chunk in request.iter_body():
+            chunks.append(chunk)
+        return b"".join(chunks)
+
+    with make_server(handler_chunkfail4) as p:
+        res = p.get("/", b"xx")
+
+    assert res.status == 500
+    assert "already consumed" in res.body.decode().lower()
+    assert "already consumed" in p.out.lower()
+
+    # Read fail - cannot iter after disconnect
+
+    async def handler_chunkfail5(request):
+        try:
+            await request.sleep_while_connected(1.0)
+        except asgineer.DisconnectedError:
+            pass
+        async for chunk in request.iter_body():
+            pass
+        chunk
+        return "ok"
+
+    if get_backend() == "mock":
+        with make_server(handler_chunkfail5) as p:
+            res = p.post("/", b"x")
+
+        assert res.status == 500
+        assert "already disconnected" in res.body.decode().lower()
+        assert "already disconnected" in p.out.lower()
+
     # Exceed memory
 
     async def handler_exceed_memory(request):
@@ -532,6 +568,90 @@ def test_wrong_output():
         assert res.status == 500
         assert "header keys and values" in res.body.decode().lower()
         assert "header keys and values" in p.out.lower()
+
+
+## Test using accept and send
+
+
+def test_using_accept_and_send():
+    async def handler(request):
+        await request.accept(200, {"xx-foo": "x"})
+        await request.send("hi!")
+
+    with make_server(handler) as p:
+        res = p.get("/")
+
+    assert res.status == 200
+    assert res.body.decode() == "hi!"
+    assert not p.out
+
+
+def test_cannot_accept_and_return():
+    async def handler(request):
+        await request.accept(200, {"xx-foo": "x"})
+        await request.send("hi!")
+        return 200, {"xx-foo": "x"}, "hi!"
+
+    with make_server(handler) as p:
+        res = p.get("/")
+
+    assert res.status == 200  # Because response has already been sent!
+    assert res.body.decode() == "hi!"
+    assert "should return None" in p.out
+
+
+def test_cannot_accept_twice():
+    async def handler(request):
+        await request.accept(200, {"xx-foo": "x"})
+        await request.accept(200, {"xx-foo": "x"})
+        await request.send("hi!")
+
+    with make_server(handler) as p:
+        res = p.get("/")
+
+    assert res.status == 200  # accept was already sent
+    assert res.body.decode() == ""  # but body was not
+    assert "cannot accept" in p.out.lower()
+
+
+def test_cannot_send_wrong_objects():
+    async def handler(request):
+        await request.accept(200, {"xx-foo": "x"})
+        await request.send({"foo": "bar"})
+
+    with make_server(handler) as p:
+        res = p.get("/")
+
+    assert res.status == 200  # accept was already sent
+    assert res.body.decode() == ""
+    assert "can only send" in p.out.lower()
+
+
+def test_cannot_send_before_accept():
+    async def handler(request):
+        await request.send("hi!")
+        await request.accept(200, {"xx-foo": "x"})
+
+    with make_server(handler) as p:
+        res = p.get("/")
+
+    assert res.status == 500
+    assert "cannot send before" in res.body.decode().lower()
+    assert "cannot send before" in p.out.lower()
+
+
+def test_cannot_send_after_closing():
+    async def handler(request):
+        await request.accept(200, {"xx-foo": "x"})
+        await request.send("hi!", more=False)
+        await request.send("hi!")
+
+    with make_server(handler) as p:
+        res = p.get("/")
+
+    assert res.status == 200
+    assert res.body.decode() == "hi!"
+    assert "cannot send to a closed" in p.out.lower()
 
 
 ## Test wrong usage

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -317,8 +317,8 @@ def test_chunking_fails():
         res = p.post("/", b"x")
 
     assert res.status == 500
-    assert "body was already consumed" in res.body.decode().lower()
-    assert "body was already consumed" in p.out.lower()
+    assert "already consumed" in res.body.decode().lower()
+    assert "already consumed" in p.out.lower()
 
     # Exceed memory
 
@@ -398,7 +398,7 @@ def test_errors():
         res = p.get("/")
 
     assert res.status == 500
-    assert "error in chunked response" in res.body.decode().lower()
+    assert "error in sending chunked response" in res.body.decode().lower()
     assert "woops" in res.body.decode()
     assert "woops" in p.out and "foo" not in p.out
     assert "xx-custom" not in res.headers
@@ -503,16 +503,16 @@ def test_wrong_output():
         res = p.get("/")
 
     assert res.status == 500
-    assert "error in chunked response" in res.body.decode().lower()
-    assert "body chunk must be" in res.body.decode().lower()
-    assert "body chunk must be" in p.out.lower()
+    assert "error in sending chunked response" in res.body.decode().lower()
+    assert "chunks must be" in res.body.decode().lower()
+    assert "chunks must be" in p.out.lower()
 
     with make_server(handler_output12) as p:
         res = p.get("/")
 
     assert res.status == 200  # too late to set status!
     assert res.body.decode() == "foo"
-    assert "body chunk must be" in p.out.lower()
+    assert "chunks must be" in p.out.lower()
 
     # Wrong header
 

--- a/tests/test_http_long.py
+++ b/tests/test_http_long.py
@@ -159,10 +159,12 @@ def test_evil_handler():
 
 def test_request_set():
 
+    loop = asyncio.get_event_loop()
+
     s1 = asgineer.RequestSet()
-    r1 = asgineer.BaseRequest(None)
-    r2 = asgineer.BaseRequest(None)
-    r3 = asgineer.BaseRequest(None)
+    r1 = asgineer.HttpRequest(None, None, None)
+    r2 = asgineer.HttpRequest(None, None, None)
+    r3 = asgineer.HttpRequest(None, None, None)
 
     s1.add(r1)
     s1.add(r2)
@@ -180,6 +182,9 @@ def test_request_set():
     # We only add r3 to s1, otherwise the gc test becomes flaky for some reason
     s1.add(r3)
 
+    # We can do this
+    loop.run_until_complete(s1.wakeup_all())  # ugly version of await ...
+
     assert len(s1) == 3
     assert len(s2) == 2
     assert len(s3) == 2
@@ -191,7 +196,6 @@ def test_request_set():
     assert len(s3) == 0
 
     # Asgineer app does this at the end
-    loop = asyncio.get_event_loop()
     loop.run_until_complete(r1._destroy())
     loop.run_until_complete(r2._destroy())
     assert len(s1) == 1

--- a/tests/test_http_long.py
+++ b/tests/test_http_long.py
@@ -162,9 +162,9 @@ def test_request_set():
     loop = asyncio.get_event_loop()
 
     s1 = asgineer.RequestSet()
-    r1 = asgineer.HttpRequest(None, None, None)
-    r2 = asgineer.HttpRequest(None, None, None)
-    r3 = asgineer.HttpRequest(None, None, None)
+    r1 = asgineer.BaseRequest(None)
+    r2 = asgineer.BaseRequest(None)
+    r3 = asgineer.BaseRequest(None)
 
     s1.add(r1)
     s1.add(r2)
@@ -181,9 +181,6 @@ def test_request_set():
 
     # We only add r3 to s1, otherwise the gc test becomes flaky for some reason
     s1.add(r3)
-
-    # We can do this
-    loop.run_until_complete(s1.wakeup_all())  # ugly version of await ...
 
     assert len(s1) == 3
     assert len(s2) == 2

--- a/tests/test_http_long.py
+++ b/tests/test_http_long.py
@@ -1,0 +1,219 @@
+"""
+Test behavior for HTTP request like streams, long-polling, and SSE.
+"""
+
+import gc
+import time
+import asyncio
+
+import asgineer
+
+from common import make_server, get_backend
+from pytest import raises, skip
+
+
+def test_stream1():
+    # Stream version using an async gen (old-style)
+    async def stream_handler(request):
+        async def stream():
+            for i in range(10):
+                await asgineer.sleep(0.1)
+                yield str(i)
+
+        return 200, {}, stream()
+
+    with make_server(stream_handler) as p:
+        res = p.get("/")
+
+    assert res.body == b"0123456789"
+    assert not p.out
+
+
+def test_stream2():
+    # New-style stream version
+    async def stream_handler(request):
+        await request.accept(200, {})
+        for i in range(10):
+            await asgineer.sleep(0.1)
+            await request.send(str(i))
+
+    with make_server(stream_handler) as p:
+        res = p.get("/")
+
+    assert res.body == b"0123456789"
+    assert not p.out
+
+
+def test_stream3():
+    # This is basically long polling
+    async def stream_handler(request):
+        await request.accept(200, {})
+        await request.sleep_while_connected(1.0)
+        for i in range(10):
+            await request.send(str(i))
+
+    with make_server(stream_handler) as p:
+        res = p.get("/")
+
+    assert res.body == b"0123456789"
+    assert not p.out
+
+    if get_backend() == "mock":
+
+        # The mock server will close the connection directly when we do not
+        # use GET. So we can test that kind of behavior.
+        with make_server(stream_handler) as p:
+            res = p.put("/")
+        assert res.body == b""
+        assert not p.out
+
+        # With POST it will even behave a bit shitty, but in a way we could
+        # expect a server to behave (receive() returning None).
+        with make_server(stream_handler) as p:
+            res = p.post("/")
+        assert res.body == b""
+        assert not p.out
+
+
+def test_stream4():
+    # This is basically sse
+    async def stream_handler(request):
+        await request.accept(200, {})
+        for i in range(10):
+            await request.sleep_while_connected(0.1)
+            await request.send(str(i))
+
+    with make_server(stream_handler) as p:
+        res = p.get("/")
+
+    assert res.body == b"0123456789"
+    assert not p.out
+
+
+def test_stream5():
+    # This is real sse (from the server side)
+    async def stream_handler(request):
+        sse_headers = {
+            "content-type": "text/event-stream",
+            "cache-control": "no-cache",
+            "connection": "keep-alive",
+        }
+        await request.accept(200, sse_headers)
+        for i in range(10):
+            await request.sleep_while_connected(0.1)
+            await request.send(f"event: message\ndata:{str(i)}\n\n")
+
+    with make_server(stream_handler) as p:
+        res = p.get("/")
+
+    val = "".join(x.split("data:")[-1] for x in res.body.decode().split("\n\n"))
+    assert val == "0123456789"
+
+
+def test_stream_wakeup():
+
+    # This tests that the request object has a wakeup (async) method.
+    # And that the signal is reset when sleep_while_connected() is entered.
+
+    async def stream_handler(request):
+        await request.accept(200, {})
+        await request.wakeup()  # internal knowledge: signal does not yet exist
+        await request.sleep_while_connected(0.01)  # force signal to be created
+        await request.wakeup()  # signal exists
+        await request.sleep_while_connected(1.0)
+        for i in range(10):
+            await request.send(str(i))
+
+    t0 = time.perf_counter()
+    with make_server(stream_handler) as p:
+        res = p.get("/")
+    t1 = time.perf_counter()
+
+    assert res.body == b"0123456789"
+    assert not p.out
+    assert 1 < (t1 - t0) < 3  # probably like 1.1
+
+
+def test_evil_handler():
+    # If, due to a "typo", the DisconnectedError is swallowed, trying
+    # to use the connection will raise IOError (which means invalid use)
+
+    if get_backend() != "mock":
+        skip("Can only test this with mock server")
+
+    async def stream_handler(request):
+        await request.accept(200, {})
+        while True:
+            try:
+                await request.sleep_while_connected(0.1)
+            except asgineer.DisconnectedError:
+                pass
+            await request.send(b"x")
+
+    with make_server(stream_handler) as p:
+        res = p.put("/")
+
+    assert res.body == b"x"
+    assert "already disconnected" in p.out.lower()
+
+
+def test_request_set():
+
+    s1 = asgineer.RequestSet()
+    r1 = asgineer.BaseRequest(None)
+    r2 = asgineer.BaseRequest(None)
+    r3 = asgineer.BaseRequest(None)
+
+    s1.add(r1)
+    s1.add(r2)
+
+    with raises(TypeError):
+        s1.add("not a request object")
+
+    # Put it in more sets
+    s2 = asgineer.RequestSet()
+    s3 = asgineer.RequestSet()
+    for r in s1:
+        s2.add(r)
+        s3.add(r)
+
+    # We only add r3 to s1, otherwise the gc test becomes flaky for some reason
+    s1.add(r3)
+
+    assert len(s1) == 3
+    assert len(s2) == 2
+    assert len(s3) == 2
+
+    # Empty s3
+    s3.discard(r1)
+    assert len(s3) == 1
+    s3.clear()
+    assert len(s3) == 0
+
+    # Asgineer app does this at the end
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(r1._destroy())
+    loop.run_until_complete(r2._destroy())
+    assert len(s1) == 1
+    assert len(s2) == 0
+
+    # But the set items are weak refs too
+    del r3
+    gc.collect()
+
+    assert len(s1) == 0
+    assert len(s2) == 0
+    assert len(s3) == 0
+
+
+if __name__ == "__main__":
+    test_stream_wakeup()
+    test_evil_handler()
+
+    test_request_set()
+
+    test_stream1()
+    test_stream2()
+    test_stream3()
+    test_stream4()
+    test_stream5()

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -15,12 +15,14 @@ def test_namespace():
 
     assert ns == {
         "BaseRequest",
-        "BaseRequest",
         "HttpRequest",
+        "RequestSet",
         "WebsocketRequest",
+        "DisconnectedError",
         "to_asgi",
         "run",
         "utils",
+        "sleep",
     }
     assert ns == set(asgineer.__all__)
 

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -181,7 +181,7 @@ def test_websocket_receive_too_much():
         p.ws_communicate("/", client)
 
     assert "hellow" in p.out
-    assert "EOFError" in p.out and "websocket disconnect" in p.out.lower()
+    assert "DisconnectedError" in p.out and "ws disconnect" in p.out.lower()
     assert "KeyError" not in p.out
 
 


### PR DESCRIPTION
This implements proper support for long-lasting connections:
* Chunked responses (already had support, using an async gen as body)
* Long polling
* Server Side Events
* Websockets (was already there, but is refactored and got some extra API)

Todo: 
* [x] Can do all the above long-lasting connections using a similar API.
* [x] Add support to sleep while a connection is active, for http requests.
* [x] ~Add support to sleep while a connection is active, for ws requests.~ -> edit examples instead
* [x] Add support for managing sets of requests.
* [x] Existing tests still pass (after only minor modifications).
* [x] Add tests (and get full coverage again).
* [x] Check todos.
* [x] Update docs.

