### PR TITLE
Fix 304s and more.

### DIFF
--- a/asgineer/_app.py
+++ b/asgineer/_app.py
@@ -146,7 +146,8 @@ async def _handle_http(handler, request):
             status, headers, body = normalize_response(result)
             # Make sure that there is a content type
             if "content-type" not in headers:
-                headers["content-type"] = guess_content_type_from_body(body)
+                if body != b"":
+                    headers["content-type"] = guess_content_type_from_body(body)
             # Convert the body
             if isinstance(body, bytes):
                 pass
@@ -175,7 +176,8 @@ async def _handle_http(handler, request):
             # the content-length, the server sets Transfer-Encoding to chunked.
             if isinstance(body, bytes):
                 where = "sending response"
-                headers.setdefault("content-length", str(len(body)))
+                if body != b"":
+                    headers.setdefault("content-length", str(len(body)))
                 await request.accept(status, headers)
                 await request.send(body, more=False)
             else:


### PR DESCRIPTION
A quick summary:

 * Place double-quotes around ETag values.
 * Convert `str` bodies to `bytes`.
 * Always set the `content-length` header.
 * Return a 304 *after* `content-type` and `content-length` (and, maybe, `content-encoding`) headers have been set.
 * Don't set a "default" `content-type` header if the body is an empty byte string.
 * Don't set a "default" `content-length` header if the body is an empty byte string.

===

I created two temporary sites to illustrate some of the issues, and the fixes:

 * https://timetagger.nfshost.com/
 * https://timetaggerpatched.nfshost.com/

The first is an unpatched copy of TimeTagger. 

The second is a patched copy. 

Both are behind an Apache proxy.

To see the problem, go to https://timetagger.nfshost.com/timetagger/. Refresh a few times. You should (eventually?) get a 404. Refresh a few times. You should (eventually?) get a page again.

(In fact, it's often enough to just go to https://timetagger.nfshost.com/timetagger/ and hit the Home link in the top left corner.)

Apache seems to be unhappy. The most likely explanation is that the `content-type` and `content-length` change if a conditional request is made:

```bash
$ curl -v -H "If-None-Match: 512dc2f89fea2c3794631fddb080e9db842542b0204cd3e2b13d1685d9f2a349" "http://localhost:5555/timetagger/" -o /dev/null
...
< HTTP/1.1 304 Not Modified
< date: Tue, 05 Mar 2024 23:29:19 GMT
< server: uvicorn
< etag: 512dc2f89fea2c3794631fddb080e9db842542b0204cd3e2b13d1685d9f2a349
< cache-control: public, must-revalidate, max-age=0
< content-type: application/octet-stream
< content-length: 0
```

The code in `utils.py` doesn't set `content-type` and `content-length` on a conditional request — but the code in `_app.py` does. And they're different from the resources' original values, so Apache is right to be suspicious.

My original fix just moved the conditional check down, after the `content-type` and `content-length` were set in `utils.py`. I discovered that in that case the `content-length` was *still* different. That's because the content length was counting characters rather than bytes.

And once I fixed the issues in `utils.py` I discovered that the changes in `_app.py` were required. You can try that out yourself: only apply the `utils.py` changes to `asgineer` in `timetagger`, and then go back and forth between the Home and App links.

I tried to make minimal changes rather than elegant changes. I won't be hurt if you decide to go in a different direction. :-)

P.S. I'll take the test sites down in a few days.